### PR TITLE
PN-19937: add LanguageUtils.resolveLanguage and propagate language to…

### DIFF
--- a/docs/openapi/remote-refs.yaml
+++ b/docs/openapi/remote-refs.yaml
@@ -17,7 +17,7 @@ components:
     cxRoleAuthFleet:
       $ref: 'https://raw.githubusercontent.com/pagopa/pn-auth-fleet/2255b75acd2e592e59bfda0f82ea9f2ecc4c45e5/docs/openapi/authenticationParameters-v1.yaml#/components/parameters/cxRoleAuthFleet'
     headerLanguage:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-auth-fleet/36fa52a16bc565eb12cf6c2ef584ea32db060ec2/docs/openapi/authenticationParameters-v1.yaml#/components/parameters/headerLanguage'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-auth-fleet/5c00a15e59db151dd79b2321a82eeae508ec3464/docs/openapi/authenticationParameters-v1.yaml#/components/parameters/headerLanguage'
   schemas:
 
     ############################################################################################

--- a/src/main/java/it/pagopa/pn/user/attributes/rest/v1/CourtesyAddressController.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/rest/v1/CourtesyAddressController.java
@@ -6,8 +6,10 @@ import it.pagopa.pn.commons.log.PnAuditLogEventType;
 import it.pagopa.pn.commons.utils.MDCUtils;
 import it.pagopa.pn.user.attributes.exceptions.*;
 import it.pagopa.pn.user.attributes.services.AddressBookService;
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.api.CourtesyApi;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.dto.*;
+import it.pagopa.pn.user.attributes.utils.LanguageUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.MDC;
@@ -140,10 +142,10 @@ public class CourtesyAddressController implements CourtesyApi {
                                                                    Mono<AddressVerificationDto> addressVerificationDto,
                                                                    List<String> pnCxGroups,
                                                                    String pnCxRole,
-                                                                   String xPagopaPnLanguage,
+                                                                   CxLanguageDto xPagopaPnLanguage,
                                                                    ServerWebExchange exchange) {
 
-
+        LanguageEnum language = LanguageUtils.resolveLanguage(xPagopaPnLanguage);
         return addressVerificationDto
                 .flatMap(addressVerificationDtoMdc -> {
                     MDC.put(MDCUtils.MDC_PN_CTX_REQUEST_ID, hashAddress(addressVerificationDtoMdc.getValue()));
@@ -161,7 +163,7 @@ public class CourtesyAddressController implements CourtesyApi {
                                 return Tuples.of(addressVerificationDto1, auditLogEvent);
                             })
 
-                            .flatMap(tupleVerCodeLogEvent -> addressBookService.saveCourtesyAddressBook(recipientId, senderId, channelType, tupleVerCodeLogEvent.getT1(), pnCxType, pnCxGroups, pnCxRole)
+                            .flatMap(tupleVerCodeLogEvent -> addressBookService.saveCourtesyAddressBook(recipientId, senderId, channelType, tupleVerCodeLogEvent.getT1(), pnCxType, pnCxGroups, pnCxRole, language)
                                     .onErrorResume(throwable ->
                                         addressBookService.manageError(tupleVerCodeLogEvent.getT2(),throwable)
                                     )

--- a/src/main/java/it/pagopa/pn/user/attributes/rest/v1/LegalAddressController.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/rest/v1/LegalAddressController.java
@@ -10,8 +10,10 @@ import it.pagopa.pn.user.attributes.exceptions.PnExceptionInsertingAddress;
 import it.pagopa.pn.user.attributes.exceptions.SercqDisabledException;
 import it.pagopa.pn.user.attributes.services.AddressBookService;
 import it.pagopa.pn.user.attributes.services.ConsentsService;
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.api.LegalApi;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.dto.*;
+import it.pagopa.pn.user.attributes.utils.LanguageUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.MDC;
@@ -99,8 +101,9 @@ public class LegalAddressController implements LegalApi {
                                                                                           Mono<AddressVerificationDto> addressVerificationDto,
                                                                                           List<String> pnCxGroups,
                                                                                           String pnCxRole,
-                                                                                          String xPagopaPnLanguage,
+                                                                                          CxLanguageDto xPagopaPnLanguage,
                                                                                           ServerWebExchange exchange) {
+        LanguageEnum language = LanguageUtils.resolveLanguage(xPagopaPnLanguage);
         addressVerificationDto.doOnNext(dto -> log.info("Start postRecipientLegalAddress - recipientId={} - pnCxType={} - senderId={} - channelType={} - addressVerificationDto={} - pnCxGroups={} - pnCxRole={}"
                 ,recipientId, pnCxType, senderId, channelType, dto, pnCxGroups, pnCxRole));
         if(!pnUserattributesConfig.isSercqEnabled() && channelType == LegalChannelTypeDto.SERCQ) {
@@ -126,7 +129,7 @@ public class LegalAddressController implements LegalApi {
                             .flatMap(hasConsents -> Boolean.TRUE.equals(hasConsents)
                                     ? Mono.empty()
                                     : Mono.just(ResponseEntity.badRequest().body(new AddressVerificationResponseDto())))
-                            .then(Mono.defer(() -> handleChannelLogic(recipientId,pnCxType,senderId,channelType,addressVerificationDtoMdc,pnCxGroups,pnCxRole,filteredAddresses)));
+                            .then(Mono.defer(() -> handleChannelLogic(recipientId,pnCxType,senderId,channelType,addressVerificationDtoMdc,pnCxGroups,pnCxRole,filteredAddresses,language)));
         });
     }
 
@@ -137,12 +140,13 @@ public class LegalAddressController implements LegalApi {
                                                                                     AddressVerificationDto addressVerificationDtoMdc,
                                                                                     List<String> pnCxGroups,
                                                                                     String pnCxRole,
-                                                                                    Flux<LegalDigitalAddressDto> filteredAddresses) {
+                                                                                    Flux<LegalDigitalAddressDto> filteredAddresses,
+                                                                                    LanguageEnum language) {
 
         if (channelType != LegalChannelTypeDto.SERCQ) {
             return filteredAddresses.collectList()
                     .flatMap(list -> executePostLegalAddressLogic(recipientId, pnCxType, senderId, channelType,
-                            addressVerificationDtoMdc, pnCxGroups, pnCxRole, list));
+                            addressVerificationDtoMdc, pnCxGroups, pnCxRole, list, language));
         }
 
         // Logica SERCQ: controllo presenza EMAIL courtesy
@@ -156,7 +160,7 @@ public class LegalAddressController implements LegalApi {
                     }
                     return filteredAddresses.collectList()
                             .flatMap(list -> executePostLegalAddressLogic(recipientId, pnCxType, senderId, channelType,
-                                    addressVerificationDtoMdc, pnCxGroups, pnCxRole, list));
+                                    addressVerificationDtoMdc, pnCxGroups, pnCxRole, list, language));
                 });
     }
 
@@ -199,7 +203,9 @@ public class LegalAddressController implements LegalApi {
                                                                                               LegalChannelTypeDto channelType,
                                                                                               AddressVerificationDto addressVerificationDtoMdc,
                                                                                               List<String> pnCxGroups,
-                                                                                              String pnCxRole, List<LegalDigitalAddressDto> filteredAddressesList) {
+                                                                                              String pnCxRole,
+                                                                                              List<LegalDigitalAddressDto> filteredAddressesList,
+                                                                                              LanguageEnum language) {
         log.info("Start executePostLegalAddressLogic - recipientId={} - pnCxType={} - senderId={} - channelType={} - addressVerificationDto={} - pnCxGroups={} - pnCxRole={}",
                 recipientId, pnCxType, senderId, channelType, addressVerificationDtoMdc.getValue(), pnCxGroups, pnCxRole);
 
@@ -218,7 +224,7 @@ public class LegalAddressController implements LegalApi {
                 .flatMap(tupleVerCodeLogEvent -> {
                     // Chiamata al metodo di salvataggio, passando la lista degli indirizzi filtrati
                     return addressBookService.saveLegalAddressBook(recipientId, senderId, channelType,
-                                    tupleVerCodeLogEvent.getT1(), pnCxType, filteredAddressesList, pnCxGroups, pnCxRole)
+                                    tupleVerCodeLogEvent.getT1(), pnCxType, filteredAddressesList, pnCxGroups, pnCxRole, language)
                             .onErrorResume(throwable -> addressBookService.manageError(tupleVerCodeLogEvent.getT2(), throwable))
                             .map(m -> {
                                 log.info("postRecipientLegalAddress done - recipientId={} - senderId={} - channelType={} res={}",

--- a/src/main/java/it/pagopa/pn/user/attributes/services/AddressBookService.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/services/AddressBookService.java
@@ -20,6 +20,7 @@ import it.pagopa.pn.user.attributes.services.utils.AppIOUtils;
 import it.pagopa.pn.user.attributes.services.utils.VerificationCodeUtils;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.externalregistry.selfcare.v1.dto.PaSummary;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.dto.*;
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
 import it.pagopa.pn.user.attributes.utils.PgUtils;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
@@ -111,10 +112,10 @@ public class AddressBookService {
      * @return risultato operazione
      */
     public Mono<SAVE_ADDRESS_RESULT> saveLegalAddressBook(String recipientId, String senderId, LegalChannelTypeDto legalChannelType, AddressVerificationDto addressVerificationDto,
-                                                          CxTypeAuthFleetDto pnCxType, List<LegalDigitalAddressDto> filteredAddressList, List<String> pnCxGroups, String pnCxRole) {
+                                                          CxTypeAuthFleetDto pnCxType, List<LegalDigitalAddressDto> filteredAddressList, List<String> pnCxGroups, String pnCxRole, LanguageEnum language) {
 
         return PgUtils.validaAccesso(pnCxType, pnCxRole, pnCxGroups)
-                .flatMap(r -> saveAddressBookLegal(recipientId, senderId, legalChannelType, addressVerificationDto, pnCxType, filteredAddressList, pnCxGroups, pnCxRole ));
+                .flatMap(r -> saveAddressBookLegal(recipientId, senderId, legalChannelType, addressVerificationDto, pnCxType, filteredAddressList, pnCxGroups, pnCxRole));
     }
 
     /**
@@ -144,7 +145,7 @@ public class AddressBookService {
      * @return risultato operazione
      */
     public Mono<SAVE_ADDRESS_RESULT> saveCourtesyAddressBook(String recipientId, String senderId, CourtesyChannelTypeDto courtesyChannelType, AddressVerificationDto addressVerificationDto,
-                                                             CxTypeAuthFleetDto pnCxType, List<String> pnCxGroups, String pnCxRole) {
+                                                             CxTypeAuthFleetDto pnCxType, List<String> pnCxGroups, String pnCxRole, LanguageEnum language) {
         return PgUtils.validaAccesso(pnCxType, pnCxRole, pnCxGroups)
                 .flatMap(r -> saveCourtesyAddressBook(recipientId, senderId, courtesyChannelType, addressVerificationDto, null));
     }

--- a/src/main/java/it/pagopa/pn/user/attributes/utils/LanguageUtils.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/utils/LanguageUtils.java
@@ -11,13 +11,13 @@ public class LanguageUtils {
 
     public static LanguageEnum resolveLanguage(CxLanguageDto headerValue) {
         if (headerValue == null) {
-            log.warn("language header fallback to IT");
+            log.warn("Language header absent, fallback to IT");
             return LanguageEnum.IT;
         }
         try {
             return LanguageEnum.fromValue(headerValue.getValue());
         } catch (IllegalArgumentException e) {
-            log.warn("language header fallback to IT");
+            log.warn("Unsupported language header, fallback to IT");
             return LanguageEnum.IT;
         }
     }

--- a/src/main/java/it/pagopa/pn/user/attributes/utils/LanguageUtils.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/utils/LanguageUtils.java
@@ -1,0 +1,24 @@
+package it.pagopa.pn.user.attributes.utils;
+
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.dto.CxLanguageDto;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LanguageUtils {
+
+    private LanguageUtils() {}
+
+    public static LanguageEnum resolveLanguage(CxLanguageDto headerValue) {
+        if (headerValue == null) {
+            log.warn("language header fallback to IT");
+            return LanguageEnum.IT;
+        }
+        try {
+            return LanguageEnum.fromValue(headerValue.getValue());
+        } catch (IllegalArgumentException e) {
+            log.warn("language header fallback to IT");
+            return LanguageEnum.IT;
+        }
+    }
+}

--- a/src/test/java/it/pagopa/pn/user/attributes/rest/v1/CourtesyAddressControllerTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/rest/v1/CourtesyAddressControllerTest.java
@@ -52,7 +52,7 @@ class CourtesyAddressControllerTest {
 
         // When
         Mono<AddressBookService.SAVE_ADDRESS_RESULT> voidReturn  = Mono.just(AddressBookService.SAVE_ADDRESS_RESULT.SUCCESS);
-        when(svc.saveCourtesyAddressBook(anyString(), anyString(), any(), any(), any(), any(), any()))
+        when(svc.saveCourtesyAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(voidReturn);
 
         // Then
@@ -79,7 +79,7 @@ class CourtesyAddressControllerTest {
         addressVerificationDto.setValue("+393333300666");
 
         // When
-        when(svc.saveCourtesyAddressBook(anyString(), anyString(), any(), any(), any(), any(), any()))
+        when(svc.saveCourtesyAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(Mono.error(new RuntimeException()));
 
         // Then
@@ -107,7 +107,7 @@ class CourtesyAddressControllerTest {
 
         // When
         Mono<AddressBookService.SAVE_ADDRESS_RESULT> voidReturn  = Mono.just(AddressBookService.SAVE_ADDRESS_RESULT.CODE_VERIFICATION_REQUIRED);
-        when(svc.saveCourtesyAddressBook(anyString(), anyString(), any(), any(), any(), any(), any()))
+        when(svc.saveCourtesyAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(voidReturn);
 
         // Then

--- a/src/test/java/it/pagopa/pn/user/attributes/rest/v1/LegalAddressControllerTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/rest/v1/LegalAddressControllerTest.java
@@ -177,7 +177,7 @@ class LegalAddressControllerTest {
         when(svc.getLegalAddressByRecipientAndSender(anyString(), anyString())).thenReturn(Flux.empty());
         when(svc.getCourtesyAddressByRecipient(any(), any(),any(),any()))
                 .thenReturn(Flux.just(courtesyEmail));
-        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
+        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(voidReturn);
         when(pnUserattributesConfig.isSercqEnabled()).thenReturn(true);
 
@@ -219,7 +219,7 @@ class LegalAddressControllerTest {
         when(svc.getLegalAddressByRecipientAndSender(anyString(), anyString())).thenReturn(Flux.empty());
         when(svc.getCourtesyAddressByRecipient(any(), any(),any(),any()))
                 .thenReturn(Flux.empty());
-        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
+        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(voidReturn);
         when(pnUserattributesConfig.isSercqEnabled()).thenReturn(true);
 
@@ -269,7 +269,7 @@ class LegalAddressControllerTest {
         when(svc.getCourtesyAddressByRecipient(any(), any(), any(), any()))
                 .thenThrow(new PnExceptionInsertingAddress(
                         ERROR_ACTIVATION_LEGAL_SERCQ_DETAIL));
-        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
+        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(voidReturn);
         when(pnUserattributesConfig.isSercqEnabled()).thenReturn(true);
 
@@ -329,7 +329,7 @@ class LegalAddressControllerTest {
                         .recipientId("recipientId")
                         .consentType(ConsentTypeDto.TOS_SERCQ)
                         .build())));
-        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
+        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(Mono.error(new RuntimeException()));
         when(pnUserattributesConfig.isSercqEnabled()).thenReturn(true);
 
@@ -370,7 +370,7 @@ class LegalAddressControllerTest {
                 .thenReturn(Mono.just(consentDto1));
         when(svc.getLegalAddressByRecipientAndSender(anyString(), anyString())).thenReturn(Flux.empty());
         when(svc.getCourtesyAddressByRecipient(any(),any(), any(),any())).thenReturn(Flux.just(courtesyEmail));
-        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
+        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(voidReturn);
         when(pnUserattributesConfig.isSercqEnabled()).thenReturn(true);
 
@@ -404,7 +404,7 @@ class LegalAddressControllerTest {
                         .recipientId("recipientId")
                         .consentType(ConsentTypeDto.TOS_SERCQ)
                         .build())));
-        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), anyList(), any(), any()))
+        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), anyList(), any(), any(), any()))
                 .thenThrow(new PnInvalidVerificationCodeException());
 
         // Then
@@ -451,7 +451,7 @@ class LegalAddressControllerTest {
         when(consentsService.getConsentByType(anyString(), eq(CxTypeAuthFleetDto.PF), eq(ConsentTypeDto.DATAPRIVACY_SERCQ), any()))
                 .thenReturn(Mono.just(consentDto1));
         when(svc.getLegalAddressByRecipientAndSender(anyString(), anyString())).thenReturn(Flux.empty());
-        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any()))
+        when(svc.saveLegalAddressBook(anyString(), anyString(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(voidReturn);
         when(pnUserattributesConfig.isSercqEnabled()).thenReturn(false);
 

--- a/src/test/java/it/pagopa/pn/user/attributes/services/AddressBookServiceTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/services/AddressBookServiceTest.java
@@ -161,7 +161,7 @@ class AddressBookServiceTest {
         Mockito.lenient().when(pnDatavaultClient.updateRecipientAddressByInternalId(anyString(), anyString(), anyString(), any(BigDecimal.class))).thenReturn(Mono.empty());
 
         // WHEN
-        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, null, null)
+        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, null, null, null)
                 .block(d);
 
         //THEN
@@ -209,7 +209,7 @@ class AddressBookServiceTest {
         legalDigitalAddressDtos.add(dto);
         Mockito.lenient().when(pnExternalRegistryClient.getAooUoIdsApi(ids)).thenReturn(Flux.empty());
         // WHEN
-        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, "default", legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF,legalDigitalAddressDtos,pnCxGroups, "role")
+        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, "default", legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, legalDigitalAddressDtos, pnCxGroups, "role", null)
                 .block(d);
 
         //THEN
@@ -240,7 +240,7 @@ class AddressBookServiceTest {
         Mockito.lenient().when(addressBookDao.saveAddressBookAndVerifiedAddress(Mockito.any(), Mockito.any(), anyList())).thenReturn(Mono.empty());
 
         // WHEN
-        Mono<AddressBookService.SAVE_ADDRESS_RESULT> mono = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, new ArrayList<>(), new ArrayList<>(), "role");
+        Mono<AddressBookService.SAVE_ADDRESS_RESULT> mono = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, new ArrayList<>(), new ArrayList<>(), "role", null);
 
         //THEN
         assertThrows(PnInvalidVerificationCodeException.class, () -> mono.block(d));
@@ -272,7 +272,7 @@ class AddressBookServiceTest {
         Mockito.when(addressBookDao.deleteVerificationCode(Mockito.any())).thenReturn(Mono.empty());
 
         // WHEN
-        Mono<AddressBookService.SAVE_ADDRESS_RESULT> mono = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, new ArrayList<>(), new ArrayList<>(), "role");
+        Mono<AddressBookService.SAVE_ADDRESS_RESULT> mono = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, new ArrayList<>(), new ArrayList<>(), "role", null);
         assertThrows(PnExpiredVerificationCodeException.class, () -> mono.block(d));
 
         verificationCode.setLastModified(Instant.now().minus(1, ChronoUnit.SECONDS));
@@ -282,7 +282,7 @@ class AddressBookServiceTest {
 
 
         // WHEN
-        Mono<AddressBookService.SAVE_ADDRESS_RESULT> monoOk = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, new ArrayList<>(), new ArrayList<>(), "role");
+        Mono<AddressBookService.SAVE_ADDRESS_RESULT> monoOk = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, new ArrayList<>(), new ArrayList<>(), "role", null);
         assertDoesNotThrow(() -> monoOk.block(d));
 
         //THEN
@@ -329,7 +329,7 @@ class AddressBookServiceTest {
 
 
         // WHEN
-        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role").block();
+        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role", null).block();
 
         //THEN
         assertNotNull(result);
@@ -377,7 +377,7 @@ class AddressBookServiceTest {
         Mockito.lenient().when(addressBookDao.deleteAddressBook(Mockito.any(), Mockito.any(), Mockito.any(), any(), eq(true))).thenReturn(Mono.empty());
 
         // WHEN
-        Mono<AddressBookService.SAVE_ADDRESS_RESULT> monoOk = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role");
+        Mono<AddressBookService.SAVE_ADDRESS_RESULT> monoOk = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role", null);
         AddressBookService.SAVE_ADDRESS_RESULT res = monoOk.block(d);
 
         //THEN
@@ -424,7 +424,7 @@ class AddressBookServiceTest {
         Mockito.lenient().when(addressBookDao.deleteAddressBook(Mockito.any(), Mockito.any(), Mockito.any(), any(), eq(true))).thenReturn(Mono.empty());
 
         //THEN
-        Mono<AddressBookService.SAVE_ADDRESS_RESULT> monoOk = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role");
+        Mono<AddressBookService.SAVE_ADDRESS_RESULT> monoOk = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role", null);
         assertDoesNotThrow(() -> monoOk.block(d));
 
     }
@@ -463,7 +463,7 @@ class AddressBookServiceTest {
         Mockito.lenient().when(addressBookDao.deleteAddressBook(Mockito.any(), Mockito.any(), Mockito.any(), any(), eq(true))).thenReturn(Mono.empty());
 
         // WHEN
-        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role").block(d);
+        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveLegalAddressBook(recipientId, null, legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, pnCxGroups, "role", null).block(d);
 
         //THEN
         assertNotNull(result);
@@ -579,7 +579,7 @@ class AddressBookServiceTest {
         Mockito.when(addressBookDao.getAllVerificationCodesByRecipient(Mockito.any(), Mockito.eq(CourtesyAddressTypeDto.COURTESY.getValue()))).thenReturn(Flux.empty());
 
         // WHEN
-        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveCourtesyAddressBook(recipientId, null, courtesyChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, null, null)
+        AddressBookService.SAVE_ADDRESS_RESULT result = addressBookService.saveCourtesyAddressBook(recipientId, null, courtesyChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, null, null, null)
                 .block(d);
 
         //THEN
@@ -711,7 +711,7 @@ class AddressBookServiceTest {
 
         //THEN
          assertThrows(PnInvalidInputException.class, () -> {
-            addressBookService.saveLegalAddressBook(recipientId, senderId, legalChannelTypeDto, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, groups, "role").block();
+            addressBookService.saveLegalAddressBook(recipientId, senderId, legalChannelTypeDto, addressVerificationDto, CxTypeAuthFleetDto.PF, addressList, groups, "role", null).block();
         });
     }
 
@@ -1764,7 +1764,7 @@ class AddressBookServiceTest {
 
         PnInvalidInputException thrown = assertThrows(
                 PnInvalidInputException.class,
-                () -> addressBookService.saveLegalAddressBook(recipientId, "NOTROOT", legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, null, null, null).block(),
+                () -> addressBookService.saveLegalAddressBook(recipientId, "NOTROOT", legalChannelType, addressVerificationDto, CxTypeAuthFleetDto.PF, null, null, null, null).block(),
                 "Expected saveLegalAddressBook() to throw, but it didn't"
         );
 

--- a/src/test/java/it/pagopa/pn/user/attributes/utils/LanguageUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/utils/LanguageUtilsTest.java
@@ -1,0 +1,40 @@
+package it.pagopa.pn.user.attributes.utils;
+
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.dto.CxLanguageDto;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LanguageUtilsTest {
+
+    @Test
+    void resolveLanguage_null_returnsIT() {
+        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage(null));
+    }
+
+    @Test
+    void resolveLanguage_IT_returnsIT() {
+        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage(CxLanguageDto.IT));
+    }
+
+    @Test
+    void resolveLanguage_DE_returnsDE() {
+        assertEquals(LanguageEnum.DE, LanguageUtils.resolveLanguage(CxLanguageDto.DE));
+    }
+
+    @Test
+    void resolveLanguage_SL_returnsSL() {
+        assertEquals(LanguageEnum.SL, LanguageUtils.resolveLanguage(CxLanguageDto.SL));
+    }
+
+    @Test
+    void resolveLanguage_FR_returnsFR() {
+        assertEquals(LanguageEnum.FR, LanguageUtils.resolveLanguage(CxLanguageDto.FR));
+    }
+
+    @Test
+    void resolveLanguage_EN_fallbackToIT() {
+        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage(CxLanguageDto.EN));
+    }
+}


### PR DESCRIPTION
… save*AddressBook

- Create LanguageUtils.resolveLanguage(CxLanguageDto): maps CxLanguageDto to LanguageEnum, falls back to IT with WARN log on null or values not yet supported by pn-templates-engine (e.g. EN); framework-level enum validation on the HTTP header is handled by Spring via the generated CxLanguageDto type
- LegalAddressController: resolve language from x-pagopa-pn-language, thread through handleChannelLogic/executePostLegalAddressLogic, pass to saveLegalAddressBook
- CourtesyAddressController: same pattern — resolve, pass to saveCourtesyAddressBook
- AddressBookService: add LanguageEnum language param to saveLegalAddressBook and saveCourtesyAddressBook (PG-facing overload) — language accepted but not yet wired into the save chain
- Update all tests: mock matchers updated to new 9/8-arg signatures; add LanguageUtilsTest covering null, valid values (IT/DE/SL/FR) and EN fallback to IT