### PR TITLE
PN-19934: WI-4.3 - add language propagation in async PEC validation f…

### DIFF
--- a/src/main/java/it/pagopa/pn/user/attributes/handler/ExternalChannelResponseHandler.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/handler/ExternalChannelResponseHandler.java
@@ -13,8 +13,8 @@ import it.pagopa.pn.user.attributes.services.utils.VerificationCodeUtils;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.datavault.v1.dto.AddressDtoDto;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.externalchannels.v1.dto.LegalMessageSentDetailsDto;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.externalchannels.v1.dto.SingleStatusUpdateDto;
-import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
 import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.server.v1.dto.LegalChannelTypeDto;
+import it.pagopa.pn.user.attributes.utils.LanguageUtils;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -94,8 +94,7 @@ public class ExternalChannelResponseHandler {
                                     String address = tuple.getT2().getValue();
                                     return verificationCodeUtils.sendToDataVaultAndSaveInDynamodb(verificationCodeEntity, tuple.getT1(), address).map(x -> address);
                                 })
-                                // TODO WI-4.1/WI-4.3: sostituire LanguageEnum.IT con LanguageUtils.resolveLanguage(verificationCodeEntity.getLanguage()) quando VerificationCodeEntity avrà il campo language
-                                .flatMap(address -> externalChannelClient.sendPecConfirm(PEC_CONFIRM_PREFIX + requestId, verificationCodeEntity.getRecipientId(), address, LanguageEnum.IT))
+                                .flatMap(address -> externalChannelClient.sendPecConfirm(PEC_CONFIRM_PREFIX + requestId, verificationCodeEntity.getRecipientId(), address, LanguageUtils.resolveLanguage(verificationCodeEntity.getLanguage())))
                                 .doOnSuccess(x -> logEvent.generateSuccess("Pec verified successfully recipientId={} hashedAddress={}", verificationCodeEntity.getRecipientId(), verificationCodeEntity.getHashedAddress()).log())
                                 .thenReturn("OK");
                     } else {

--- a/src/main/java/it/pagopa/pn/user/attributes/handler/PecValidationExpiredResponseHandler.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/handler/PecValidationExpiredResponseHandler.java
@@ -1,7 +1,7 @@
 package it.pagopa.pn.user.attributes.handler;
 
 import it.pagopa.pn.user.attributes.middleware.wsclient.PnExternalChannelClient;
-import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
+import it.pagopa.pn.user.attributes.utils.LanguageUtils;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,8 +20,7 @@ public class PecValidationExpiredResponseHandler {
 
 
     public Mono<Void> consumePecValidationExpiredEvent(String internalId, String address, String language) {
-        // TODO WI-4.3: sostituire LanguageEnum.IT con LanguageUtils.resolveLanguage(language) quando resolveLanguage(String) sarà disponibile da WI-1.2
-        return externalChannelClient.sendCourtesyPecRejected(PEC_INVALID_PREFIX + UUID.randomUUID(), internalId, address, LanguageEnum.IT)
+        return externalChannelClient.sendCourtesyPecRejected(PEC_INVALID_PREFIX + UUID.randomUUID(), internalId, address, LanguageUtils.resolveLanguage(language))
                 .then();
     }
 

--- a/src/main/java/it/pagopa/pn/user/attributes/middleware/queue/consumer/ActionHandler.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/middleware/queue/consumer/ActionHandler.java
@@ -46,8 +46,7 @@ public class ActionHandler {
                     MDCUtils.addMDCToContextAndExecute(ioNotificationService.consumeIoActivationEvent(action.getActionId(), action.getInternalId(), action.getCheckFromWhen()).then()).block();
                     break;
                 case PEC_REJECTED_ACTION:
-                    // TODO WI-4.3: sostituire null con action.getLanguage() quando il campo language sarà aggiunto ad Action
-                    MDCUtils.addMDCToContextAndExecute(pecValidationExpiredResponseHandler.consumePecValidationExpiredEvent(action.getInternalId(), action.getAddress(), null)).block();
+                    MDCUtils.addMDCToContextAndExecute(pecValidationExpiredResponseHandler.consumePecValidationExpiredEvent(action.getInternalId(), action.getAddress(), action.getLanguage())).block();
                     break;
                 default:
                     String msg = "Unknown action type: " + action.getType();

--- a/src/main/java/it/pagopa/pn/user/attributes/middleware/queue/entities/Action.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/middleware/queue/entities/Action.java
@@ -25,5 +25,7 @@ public class Action {
 
     private ActionType type;
 
+    private String language;
+
     @lombok.ToString.Exclude private String address;
 }

--- a/src/main/java/it/pagopa/pn/user/attributes/utils/LanguageUtils.java
+++ b/src/main/java/it/pagopa/pn/user/attributes/utils/LanguageUtils.java
@@ -21,4 +21,18 @@ public class LanguageUtils {
             return LanguageEnum.IT;
         }
     }
+
+    public static LanguageEnum resolveLanguage(String language) {
+        if (language == null) {
+            log.warn("Language field absent (pre-feature record or missing payload field), fallback to IT");
+            return LanguageEnum.IT;
+        }
+        try {
+            return LanguageEnum.fromValue(language);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unsupported language value '{}', fallback to IT", language);
+            return LanguageEnum.IT;
+        }
+    }
+
 }

--- a/src/test/java/it/pagopa/pn/user/attributes/handler/ExternalChannelResponseHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/handler/ExternalChannelResponseHandlerTest.java
@@ -246,6 +246,42 @@ class ExternalChannelResponseHandlerTest {
     }
 
     @Test
+    void consumeExternalChannelResponse_codevalid_languageDE_propagatesDE() {
+        //GIVEN
+        String requestId = UUID.randomUUID().toString();
+        SingleStatusUpdateDto singleStatusUpdateDto = new SingleStatusUpdateDto();
+        singleStatusUpdateDto.setDigitalLegal(new LegalMessageSentDetailsDto());
+        singleStatusUpdateDto.getDigitalLegal().setRequestId(requestId);
+        singleStatusUpdateDto.getDigitalLegal().setEventCode("C003");
+
+        String recipientId = "PF-123e4567-e89b-12d3-a456-426714174000";
+        LegalChannelTypeDto legalChannelType = LegalChannelTypeDto.PEC;
+
+        VerificationCodeEntity verificationCode = new VerificationCodeEntity(recipientId, "hashed", legalChannelType.getValue(), null, LegalAddressTypeDto.LEGAL.getValue(), "pec@pec.it");
+        verificationCode.setVerificationCode("12345");
+        verificationCode.setCodeValid(true);
+        verificationCode.setLastModified(Instant.now().minusSeconds(1));
+        verificationCode.setLanguage("DE");
+
+        Mockito.when(addressBookDao.getVerificationCodeByRequestId(any())).thenReturn(Mono.just(verificationCode));
+        Mockito.when(pnUserattributesConfig.getExternalChannelDigitalCodesSuccess()).thenReturn(List.of("C003"));
+        Mockito.when(addressBookDao.saveAddressBookAndVerifiedAddress(any(), any(), any())).thenReturn(Mono.empty());
+        Mockito.when(pnDatavaultClient.updateRecipientAddressByInternalId(any(), any(), any())).thenReturn(Mono.empty());
+        Mockito.when(addressBookDao.deleteVerificationCode(any())).thenReturn(Mono.empty());
+        Mockito.when(pnExternalChannelClient.sendPecConfirm(anyString(), anyString(), anyString(), any(LanguageEnum.class))).thenReturn(Mono.just(UUID.randomUUID().toString()));
+        Mockito.when(addressBookService.getLegalAddressByRecipientAndSender(anyString(), anyString())).thenReturn(Flux.just(new LegalDigitalAddressDto().senderId("senderId").recipientId("recipientId").channelType(LegalChannelTypeDto.PEC)));
+        Mockito.when(addressBookService.prepareAndDeleteAddresses(any())).thenReturn(Mono.just(List.of()));
+        Mockito.when(pnDatavaultClient.getVerificationCodeAddressByInternalId(any(), any())).thenReturn(Mono.just(new AddressDtoDto().value("value")));
+
+        // WHEN
+        Mono<Void> mono = externalChannelResponseHandler.consumeExternalChannelResponse(singleStatusUpdateDto);
+        Assertions.assertDoesNotThrow(() -> mono.block(d));
+
+        //THEN
+        Mockito.verify(pnExternalChannelClient).sendPecConfirm(anyString(), anyString(), anyString(), Mockito.eq(LanguageEnum.DE));
+    }
+
+    @Test
     void consumeExternalChannelResponse_vcAddressNotFound() {
         //GIVEN
         String requestId = UUID.randomUUID().toString();

--- a/src/test/java/it/pagopa/pn/user/attributes/handler/PecValidationExpiredResponseHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/handler/PecValidationExpiredResponseHandlerTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.user.attributes.handler;
 
 import it.pagopa.pn.user.attributes.middleware.wsclient.PnExternalChannelClient;
+import it.pagopa.pn.user.attributes.user.attributes.generated.openapi.msclient.templatesengine.model.LanguageEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,5 +38,32 @@ class PecValidationExpiredResponseHandlerTest {
 
         Assertions.assertThrows(Exception.class, () -> pecValidationExpiredResponseHandler.consumePecValidationExpiredEvent("fghjkl", "435678@fghj", null).block());
 
+    }
+
+    @Test
+    void consumePecValidationExpiredEvent_languageDE_propagatesDE() {
+        Mockito.when(pnExternalChannelClient.sendCourtesyPecRejected(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(Mono.empty());
+
+        Assertions.assertDoesNotThrow(() -> pecValidationExpiredResponseHandler.consumePecValidationExpiredEvent("fghjkl", "435678@fghj", "DE").block());
+
+        Mockito.verify(pnExternalChannelClient).sendCourtesyPecRejected(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.eq(LanguageEnum.DE));
+    }
+
+    @Test
+    void consumePecValidationExpiredEvent_languageNull_fallbackToIT() {
+        Mockito.when(pnExternalChannelClient.sendCourtesyPecRejected(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(Mono.empty());
+
+        Assertions.assertDoesNotThrow(() -> pecValidationExpiredResponseHandler.consumePecValidationExpiredEvent("fghjkl", "435678@fghj", null).block());
+
+        Mockito.verify(pnExternalChannelClient).sendCourtesyPecRejected(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.eq(LanguageEnum.IT));
+    }
+
+    @Test
+    void consumePecValidationExpiredEvent_languageUnsupported_fallbackToIT() {
+        Mockito.when(pnExternalChannelClient.sendCourtesyPecRejected(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(Mono.empty());
+
+        Assertions.assertDoesNotThrow(() -> pecValidationExpiredResponseHandler.consumePecValidationExpiredEvent("fghjkl", "435678@fghj", "XX").block());
+
+        Mockito.verify(pnExternalChannelClient).sendCourtesyPecRejected(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.eq(LanguageEnum.IT));
     }
 }

--- a/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/consumer/ActionHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/consumer/ActionHandlerTest.java
@@ -120,4 +120,31 @@ class ActionHandlerTest {
 
         Assertions.assertDoesNotThrow(() -> actionHandler.pnUserAttributesActionConsumer(message));
     }
+
+    @Test
+    void pnUserAttributesPecValidationExpiredActionConsumer_withLanguage() {
+        Mockito.when(pecValidationExpiredResponseHandler.consumePecValidationExpiredEvent(Mockito.any(), Mockito.anyString(), Mockito.eq("DE"))).thenReturn(Mono.empty());
+        Message<Action> message = new Message<Action>() {
+            @Override
+            public Action getPayload() {
+                Action action = Action.builder()
+                        .internalId("123")
+                        .actionId("123456")
+                        .type(ActionType.PEC_REJECTED_ACTION)
+                        .address("email@email.it")
+                        .language("DE")
+                        .build();
+                return action;
+            }
+
+            @Override
+            public MessageHeaders getHeaders() {
+                MessageHeaders messageHeaders = new MessageHeaders(Map.of());
+                return messageHeaders;
+            }
+        };
+
+        Assertions.assertDoesNotThrow(() -> actionHandler.pnUserAttributesActionConsumer(message));
+        Mockito.verify(pecValidationExpiredResponseHandler).consumePecValidationExpiredEvent(Mockito.any(), Mockito.anyString(), Mockito.eq("DE"));
+    }
 }

--- a/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/entities/ActionEventTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/entities/ActionEventTest.java
@@ -14,7 +14,7 @@ class ActionEventTest {
     private ActionEvent actionEvent;
 
     private Action action = new Action("testID","testInternalID",
-            Instant.now(),new SentNotificationV25(),Instant.now(),ActionType.IO_ACTIVATED_ACTION, null);
+            Instant.now(),new SentNotificationV25(),Instant.now(),ActionType.IO_ACTIVATED_ACTION, null, null);
     private StandardEventHeader standardEventHeader = new StandardEventHeader();
 
     @BeforeEach

--- a/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/entities/ActionTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/entities/ActionTest.java
@@ -23,26 +23,26 @@ class ActionTest {
 
     @BeforeEach
     void setUp() {
-        action = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null);
+        action = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null, null);
     }
 
     @Test
     void testEquals() {
-        Action toCompare = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null);
+        Action toCompare = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null, null);
         boolean equals = action.equals(toCompare);
         assertTrue(equals);
     }
 
     @Test
     void canEqual() {
-        Action toCompare = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null);
+        Action toCompare = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null, null);
         boolean equals = action.canEqual(toCompare);
         assertTrue(equals);
     }
 
     @Test
     void testNotEquals() {
-        Action toCompare = new Action("NOT",internalId,checkFromWhen,sentNotification,timeStamp,actionType, null);
+        Action toCompare = new Action("NOT",internalId,checkFromWhen,sentNotification,timeStamp,actionType, null, null);
         boolean equals = action.equals(toCompare);
         assertFalse(equals);
     }
@@ -71,7 +71,7 @@ class ActionTest {
 
     @Test
     void testHashCode() {
-        Action toCompare = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null);
+        Action toCompare = new Action(actionId,internalId,checkFromWhen,sentNotification,timeStamp,actionType, null, null);
         assertEquals(action.hashCode(),toCompare.hashCode());
     }
 

--- a/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/entities/ActionTypeTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/middleware/queue/entities/ActionTypeTest.java
@@ -17,7 +17,7 @@ class ActionTypeTest {
     @BeforeEach
     void setUp() {
         action = new Action("testID","testInternalID",
-                Instant.now(),new SentNotificationV25(),Instant.now(),ActionType.IO_ACTIVATED_ACTION, null);
+                Instant.now(),new SentNotificationV25(),Instant.now(),ActionType.IO_ACTIVATED_ACTION, null, null);
     }
 
 

--- a/src/test/java/it/pagopa/pn/user/attributes/utils/LanguageUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/user/attributes/utils/LanguageUtilsTest.java
@@ -10,7 +10,8 @@ class LanguageUtilsTest {
 
     @Test
     void resolveLanguage_null_returnsIT() {
-        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage(null));
+        CxLanguageDto nullLanguage = null;
+        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage(nullLanguage));
     }
 
     @Test
@@ -36,5 +37,37 @@ class LanguageUtilsTest {
     @Test
     void resolveLanguage_EN_fallbackToIT() {
         assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage(CxLanguageDto.EN));
+    }
+
+    // resolveLanguage(String) overload
+
+    @Test
+    void resolveLanguageString_null_returnsIT() {
+        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage((String) null));
+    }
+
+    @Test
+    void resolveLanguageString_IT_returnsIT() {
+        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage("IT"));
+    }
+
+    @Test
+    void resolveLanguageString_DE_returnsDE() {
+        assertEquals(LanguageEnum.DE, LanguageUtils.resolveLanguage("DE"));
+    }
+
+    @Test
+    void resolveLanguageString_SL_returnsSL() {
+        assertEquals(LanguageEnum.SL, LanguageUtils.resolveLanguage("SL"));
+    }
+
+    @Test
+    void resolveLanguageString_FR_returnsFR() {
+        assertEquals(LanguageEnum.FR, LanguageUtils.resolveLanguage("FR"));
+    }
+
+    @Test
+    void resolveLanguageString_unsupported_fallbackToIT() {
+        assertEquals(LanguageEnum.IT, LanguageUtils.resolveLanguage("XX"));
     }
 }


### PR DESCRIPTION
…lows

- Add language field to Action
- Add LanguageUtils.resolveLanguage(String) overload with IT fallback and WARN logging
- Replace hardcoded LanguageEnum.IT in ExternalChannelResponseHandler and PecValidationExpiredResponseHandler
- Add/update unit tests for all modified components